### PR TITLE
Add bare bones ModelData.h

### DIFF
--- a/src/aq/CMakeLists.txt
+++ b/src/aq/CMakeLists.txt
@@ -26,6 +26,7 @@ list( APPEND aq_src_files
   ModelAuxControl.h
   ModelAuxCovariance.h
   ModelAuxIncrement.h
+  ModelData.h
   BackgroundCheck.h
   BackgroundCheck.cc
   FinalCheck.h

--- a/src/aq/ModelData.h
+++ b/src/aq/ModelData.h
@@ -1,0 +1,63 @@
+/*
+ * (C) Copyright 2009-2016 ECMWF.
+ * (C) Copyright 2021-2022 CERFACS.
+ *
+ * This software is licensed under the terms of the Apache Licence Version 2.0
+ * which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+ * In applying this licence, ECMWF does not waive the privileges and immunities
+ * granted to it by virtue of its status as an intergovernmental organisation nor
+ * does it submit to any jurisdiction.
+ */
+
+#ifndef AQ_MODELDATA_H_
+#define AQ_MODELDATA_H_
+
+#include <iostream>
+#include <string>
+
+#include "eckit/memory/NonCopyable.h"
+#include "oops/util/ObjectCounter.h"
+#include "oops/util/Printable.h"
+
+namespace eckit {
+  class LocalConfiguration;
+}
+
+namespace aq {
+  class Geometry;
+
+/// Model data for the AQ model.
+/*!
+ * This class is used by SABER/VADER to obtain model-specific constants
+ * VADER is not used yet, so this is currently empty
+ */
+
+// -----------------------------------------------------------------------------
+
+class ModelData : public util::Printable,
+                  private eckit::NonCopyable,
+                  private util::ObjectCounter<ModelData> {
+ public:
+  static const std::string classname() {return "aq::ModelData";}
+
+  explicit ModelData(const Geometry &) {}
+  virtual ~ModelData() {}
+  ModelData(const ModelData &) = delete;
+  ModelData(ModelData &&) = default;
+  const ModelData & operator=(const ModelData &) = delete;
+  ModelData & operator=(ModelData &&) = default;
+
+  const eckit::LocalConfiguration modelData() const {
+    eckit::LocalConfiguration modelData;
+    return modelData;
+  }
+
+ private:
+  void print(std::ostream &) const {}
+};
+
+// -----------------------------------------------------------------------------
+
+}  // namespace aq
+
+#endif  // AQ_MODELDATA_H_

--- a/src/aq/Traits.h
+++ b/src/aq/Traits.h
@@ -25,6 +25,7 @@
 #include "aq/ModelAuxControl.h"
 #include "aq/ModelAuxCovariance.h"
 #include "aq/ModelAuxIncrement.h"
+#include "aq/ModelData.h"
 #include "aq/ObsAuxControl.h"
 #include "aq/ObsAuxCovariance.h"
 #include "aq/ObsAuxIncrement.h"

--- a/src/aq/TraitsFwd.h
+++ b/src/aq/TraitsFwd.h
@@ -64,6 +64,7 @@ struct Traits {
   typedef aq::ModelAuxControl     ModelAuxControl;
   typedef aq::ModelAuxIncrement   ModelAuxIncrement;
   typedef aq::ModelAuxCovariance  ModelAuxCovariance;
+  typedef aq::ModelData           ModelData;
 };
 
 struct ObsTraits {


### PR DESCRIPTION
Adds a bare-bones ModelData class and adds this to the traits. This is required for OOPS PR: https://github.com/JCSDA-internal/oops/pull/2227 (with related SABER and VADER changes).